### PR TITLE
Feat: 一番近いアメダスから情報を取得 1時間毎

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,9 @@ PODS:
   - device_info_plus (0.0.1):
     - Flutter
   - Flutter (1.0.0)
+  - geolocator_apple (1.2.0):
+    - Flutter
+    - FlutterMacOS
   - health (13.1.1):
     - Flutter
   - home_widget (0.0.1):
@@ -22,6 +25,7 @@ DEPENDENCIES:
   - amplify_secure_storage (from `.symlinks/plugins/amplify_secure_storage/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
+  - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - health (from `.symlinks/plugins/health/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -36,6 +40,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
+  geolocator_apple:
+    :path: ".symlinks/plugins/geolocator_apple/darwin"
   health:
     :path: ".symlinks/plugins/health/ios"
   home_widget:
@@ -50,6 +56,7 @@ SPEC CHECKSUMS:
   amplify_secure_storage: 3edc30177ffefbcee786c408a21c02f8ab9f168e
   device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   health: 0488159eaa0cb4551cb066fe469c6a647416ca1a
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This app obtains your current location and displays the weather at the nearest observation station.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/lib/tabs/home.dart
+++ b/lib/tabs/home.dart
@@ -1,19 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../healthkit/healthkit.dart';
+import '../temperature/amedas.dart';
 
 
 class Home extends StatefulWidget {
   const Home({super.key, required this.title});
-
-  // This widget is the home page of your application. It is stateful, meaning
-  // that it has a State object (defined below) that contains fields that affect
-  // how it looks.
-
-  // This class is the configuration for the state. It holds the values (in this
-  // case the title) provided by the parent (in this case the App widget) and
-  // used by the build method of the State. Fields in a Widget subclass are
-  // always marked "final".
 
   final String title;
 
@@ -23,11 +15,14 @@ class Home extends StatefulWidget {
 
 class _HomeState extends State<Home> {
   int _counter = 0;
+  final amedas = AmedasService();
   // 初期化の時にUsersDefaultから所得して値を設定しないとウィジェットが更新されない
   @override
   void initState() {
+    print('init');
     super.initState();
     _loadCounterFromIOS();
+    amedas.fetchNearestAmedasData();
   }
 
   Future<void> _loadCounterFromIOS() async {
@@ -37,7 +32,7 @@ class _HomeState extends State<Home> {
         _counter = value as int? ?? 0;
       });
     } catch (e) {
-      // エラー処理
+      //print(e);
     }
   }
 

--- a/lib/temperature/amedas.dart
+++ b/lib/temperature/amedas.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:geolocator/geolocator.dart';
+
+class AmedasService {
+  // 最寄りアメダスAPI
+  final String nearestAmedasUrl = "https://api.cultivationdata.net/nearest_amds";
+
+  // メイン処理
+  Future<void> fetchNearestAmedasData() async {
+    print("[Amedas] 現在地取得開始");
+    final position = await _getCurrentLocation();
+    if (position == null) {
+      print("[Amedas] 位置情報が取得できませんでした。");
+      return;
+    }
+    print("[Amedas] 現在地取得成功: lat=${position.latitude}, lon=${position.longitude}");
+
+    print("[Amedas] 最寄り観測所検索開始");
+    final stationNo = await _getNearestStationNo(position.latitude, position.longitude);
+    if (stationNo == null) {
+      print("[Amedas] 最寄りの観測所が見つかりませんでした。");
+      return;
+    }
+    print("[Amedas] 最寄り観測所番号: $stationNo");
+
+    print("[Amedas] 最新アメダスデータ取得開始");
+    final weather = await _getLatestAmedasData(stationNo);
+    if (weather == null) {
+      print("[Amedas] アメダスデータが取得できませんでした。");
+      return;
+    }
+
+    print("[Amedas] 🌡️ 気温: ${weather['temp']} ℃");
+    print("[Amedas] 💧 湿度: ${weather['humidity']} %");
+  }
+
+  // 現在地取得
+  Future<Position?> _getCurrentLocation() async {
+    print("[Amedas] 位置情報サービス有効確認");
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    LocationPermission permission = await Geolocator.checkPermission();
+
+    if (!serviceEnabled) {
+      print("[Amedas] 位置情報サービスが無効です");
+      return null;
+    }
+    if (permission == LocationPermission.deniedForever) {
+      print("[Amedas] 位置情報の権限が永久に拒否されています");
+      return null;
+    }
+    if (permission == LocationPermission.denied) {
+      print("[Amedas] 位置情報の権限が未許可。リクエストします");
+      permission = await Geolocator.requestPermission();
+      if (permission != LocationPermission.always && permission != LocationPermission.whileInUse) {
+        print("[Amedas] 位置情報の権限が許可されませんでした");
+        return null;
+      }
+    }
+
+    print("[Amedas] 位置情報の取得リクエスト");
+    return await Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high);
+  }
+
+  // 最寄り観測所番号を返す
+  Future<String?> _getNearestStationNo(double lat, double lon) async {
+    final url = "${nearestAmedasUrl}?lat=$lat&lon=$lon";
+    print("[Amedas] 最寄り観測所APIリクエスト: $url");
+    final res = await http.get(Uri.parse(url));
+    if (res.statusCode != 200) {
+      print("[Amedas] 最寄り観測所API取得失敗: status=${res.statusCode}");
+      return null;
+    }
+    final jsonData = json.decode(utf8.decode(res.bodyBytes));
+    if (jsonData == null || jsonData['0'] == null || jsonData['0']['obs_number'] == null) {
+      print("[Amedas] 最寄り観測所データが空");
+      return null;
+    }
+    final stationNo = jsonData['0']['obs_number'].toString();
+    print("[Amedas] 最寄り観測所番号取得: $stationNo");
+    return stationNo;
+  }
+
+  // 最新アメダスデータ取得
+  Future<Map<String, dynamic>?> _getLatestAmedasData(String stationNo) async {
+    final url = "https://api.cultivationdata.net/amds?no=$stationNo";
+    print("[Amedas] 最新アメダスデータAPIリクエスト: $url");
+    final res = await http.get(Uri.parse(url));
+    if (res.statusCode != 200) {
+      print("[Amedas] 最新アメダスデータ取得失敗: status=${res.statusCode}");
+      return null;
+    }
+    final jsonData = json.decode(utf8.decode(res.bodyBytes));
+    if (jsonData == null || jsonData['temp'] == null || jsonData['humidity'] == null) {
+      print("[Amedas] データが空");
+      return null;
+    }
+    print("[Amedas] データ取得成功: temp=${jsonData['temp']}, humidity=${jsonData['humidity']}");
+    return {
+      'temp': jsonData['temp'][0],
+      'humidity': jsonData['humidity'][0],
+    };
+  }
+
+  // ...不要な旧関数は削除...
+  // 以降、必要に応じて拡張可
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -8,6 +8,7 @@ import Foundation
 import amplify_auth_cognito
 import amplify_secure_storage
 import device_info_plus
+import geolocator_apple
 import package_info_plus
 import path_provider_foundation
 
@@ -15,6 +16,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AmplifyAuthCognitoPlugin.register(with: registry.registrar(forPlugin: "AmplifyAuthCognitoPlugin"))
   AmplifySecureStoragePlugin.register(with: registry.registrar(forPlugin: "AmplifySecureStoragePlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.7"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -193,6 +201,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "79e0c23480ff85dc68de79e2cd6334add97e48f7f4865d17686dd6ea81a47e8c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.11"
   device_info_plus:
     dependency: transitive
     description:
@@ -272,6 +288,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: c4e966f0a7a87e70049eac7a2617f9e16fd4c585a26e4330bdfc3a71e6a721f3
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.3"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   graphs:
     dependency: transitive
     description:
@@ -280,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   health:
     dependency: "direct main"
     description:
@@ -297,7 +385,7 @@ packages:
     source: hosted
     version: "0.8.0"
   http:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: http
       sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,8 @@ dependencies:
   amplify_flutter: ^2.6.4
   home_widget: ^0.8.0
   health: ^13.1.1
+  geolocator: ^14.0.2
+  http: ^1.4.0
   
 
 dev_dependencies:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,8 +7,11 @@
 #include "generated_plugin_registrant.h"
 
 #include <amplify_db_common/amplify_db_common_plugin.h>
+#include <geolocator_windows/geolocator_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AmplifyDbCommonPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AmplifyDbCommonPlugin"));
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   amplify_db_common
+  geolocator_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## 最寄りアメダス観測所から気象データを取得する機能を追加

### 概要
- 現在地から最も近いアメダス観測所をAPIで検索し、その観測所の最新気象データ（気温・湿度など）を取得できるようにしました。

### 主な変更点
- `AmedasService`クラスを実装
  - 位置情報取得
  - 最寄り観測所APIへのリクエスト・観測所番号の取得
  - 観測所番号を用いた最新気象データの取得
- 取得した気温・湿度をデバッグ出力

ご確認よろしくお願いします。